### PR TITLE
Make ip and netmask public in NetInfo

### DIFF
--- a/Pod/Classes/LANScanner.swift
+++ b/Pod/Classes/LANScanner.swift
@@ -44,8 +44,8 @@ import UIKit
 open class LANScanner: NSObject {
     
     public struct NetInfo {
-        let ip: String
-        let netmask: String
+        public let ip: String
+        public let netmask: String
     }
     
     


### PR DESCRIPTION
Since they are 'internal' by default, they were not accessible.